### PR TITLE
gimbalabs: build test via plutus-starter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+Jan 10
+
+There is https://github.com/input-output-hk/plutus-starter/issues/56
+How can I add V2 support?
+
+I need a test, a working example of plutus-app using v2 scripts. 
+I think there exists V2 version of 
+https://gitlab.com/gimbalabs/plutus-pbl-summer-2022/plutus-always-succeeds
+
+Therefore I should add plutus-always-succeds and see if it works.
+its tag is specified to be `v2022-04-06`
+
 Jan 9
 
 ## Reading README:

--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ benchmarks: true
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/plutus-apps.git
-  tag: v0.1.0
+  tag: v2022-04-06
   subdir:
     doc
     freer-extras

--- a/plutus-starter.cabal
+++ b/plutus-starter.cabal
@@ -41,8 +41,8 @@ common lang
 library
     import: lang
     exposed-modules:
-      MyModule
-      Plutus.Contracts.Game
+      MyFirstPlutusCompiler
+      MyFirstPlutusScript
     build-depends:
       base >= 4.9 && < 5,
       aeson -any,
@@ -59,7 +59,7 @@ library
       plutus-script-utils -any,
       text -any,
       lens -any,
-    hs-source-dirs: src examples/src
+    hs-source-dirs: src 
 
 test-suite plutus-example-projects-test
   import: lang
@@ -83,21 +83,3 @@ test-suite plutus-example-projects-test
     tasty-hedgehog >=0.2.0.0
 
 
-executable plutus-starter-pab
-  import: lang
-  main-is: Main.hs
-  hs-source-dirs: pab
-  ghc-options:
-    -threaded
-  build-depends:
-    base >= 4.9 && < 5,
-    data-default -any,
-    plutus-contract -any,
-    plutus-pab -any,
-    plutus-starter -any,
-    aeson -any,
-    freer-simple -any,
-    prettyprinter -any,
-    freer-extras -any,
-    plutus-ledger -any,
-    openapi3 -any,

--- a/plutus-starter.cabal
+++ b/plutus-starter.cabal
@@ -59,6 +59,8 @@ library
       plutus-script-utils -any,
       text -any,
       lens -any,
+      cardano-api,
+      serialize
     hs-source-dirs: src 
 
 test-suite plutus-example-projects-test

--- a/plutus-starter.cabal
+++ b/plutus-starter.cabal
@@ -60,7 +60,7 @@ library
       text -any,
       lens -any,
       cardano-api,
-      serialize
+      serialise
     hs-source-dirs: src 
 
 test-suite plutus-example-projects-test

--- a/src/MyFirstPlutusCompiler.hs
+++ b/src/MyFirstPlutusCompiler.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+
+module MyFirstPlutusCompiler where
+
+import Cardano.Api
+import Cardano.Api.Shelley (PlutusScript (..))
+import Codec.Serialise (serialise)
+import Data.Aeson
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Short as SBS
+import qualified Ledger
+import Plutus.V1.Ledger.Api (toData)
+import PlutusTx (Data (..), ToData)
+import qualified MyFirstPlutusScript as MFS
+
+dataToScriptData :: Data -> ScriptData
+dataToScriptData (Constr n xs) = ScriptDataConstructor n $ dataToScriptData <$> xs
+dataToScriptData (I n) = ScriptDataNumber n
+dataToScriptData (B n) = ScriptDataBytes n
+dataToScriptData (Map xs) = ScriptDataMap $ [(dataToScriptData x, dataToScriptData y) | (x, y) <- xs]
+dataToScriptData (List xs) = ScriptDataList $ dataToScriptData <$> xs
+
+writeJSON :: ToData a => FilePath -> a -> IO ()
+writeJSON file = LBS.writeFile file . encode . scriptDataToJson ScriptDataJsonDetailedSchema . dataToScriptData . toData
+
+toJSON :: IO ()
+toJSON = writeJSON "output/simpleData.json" ()
+
+writeValidator :: FilePath -> Ledger.Validator -> IO (Either (FileError ()) ())
+writeValidator file = writeFileTextEnvelope @(PlutusScript PlutusScriptV1) file Nothing . PlutusScriptSerialised . SBS.toShort . LBS.toStrict . serialise . Ledger.unValidatorScript
+
+writeMyFirstValidatorScript :: IO (Either (FileError ()) ())
+writeMyFirstValidatorScript = writeValidator "output/my-first-script.plutus" MFS.validator

--- a/src/MyFirstPlutusScript.hs
+++ b/src/MyFirstPlutusScript.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module MyFirstPlutusScript where
+
+import Plutus.V1.Ledger.Api (BuiltinData, Validator, mkValidatorScript)
+import PlutusTx (compile)
+
+{-# INLINEABLE myValidator #-}
+myValidator :: BuiltinData -> BuiltinData -> BuiltinData -> ()
+myValidator _ _ _ = ()
+
+validator :: Validator
+validator = mkValidatorScript $$(compile [||myValidator||])


### PR DESCRIPTION
 think there exists V2 version of                                                                                     
https://gitlab.com/gimbalabs/plutus-pbl-summer-2022/plutus-always-succeeds                                             
                                                                                                                       
Therefore I should add plutus-always-succeds and see if it works.                                                      
its tag is specified to be `v2022-04-06`

to test:
```
nix-shell$ cd /always-succeeds

# this may take a while the first time
cabal update
cabal repl 

Prelude MyFirstPlutusCompiler>

Right()
```